### PR TITLE
Fixes some tiny typos and inconsistencies in Rust documentation

### DIFF
--- a/docs/Rust/section2/loops.md
+++ b/docs/Rust/section2/loops.md
@@ -166,7 +166,7 @@ Besides being much more concise, there is no worry about having an `index out of
 
 ## What is happening here?
 
-A the core loops are illustrated above.  Notice the `break` keyword being used within `loop`, so the playground does not run infinitely (and so other loops can run!).
+All the core loops are illustrated above.  Notice the `break` keyword being used within `loop`, so the playground does not run infinitely (and so other loops can run!).
 
 
 

--- a/docs/Rust/section4/panic.md
+++ b/docs/Rust/section4/panic.md
@@ -5,7 +5,7 @@ sidebar_label: Panic! in Rust
 description: Discover what panic! in Rust is, and when you should panic.
 ---
 
-Previously we mentioned the concept of **panicking**, or the program stopping during runtime.  This usually to prevent something unsafe from occurring, such as the possibility of invalid data being accessed in memory.  A panic is a **irrecoverable** error.
+Previously we mentioned the concept of **panicking**, or the program stopping during runtime.  This is usually to prevent something unsafe from occurring, such as the possibility of invalid data being accessed in memory.  A panic is a **irrecoverable** error.
 
 However, it is possible to invoke a panic using the `panic!` macro:
 
@@ -26,6 +26,6 @@ thread 'main' panicked at 'explicit panic', src/main.rs:3:5
 note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
 ```
 
-There are a few methods that could cause a panic, namely within using `Result`.  Methods such as `unwrap()` and `expect()` an cause a panic if the `Result` is `None`, as the error is not being handled.  As a result, the program simply panics and closes to prevent any further unwanted behavior.
+There are a few methods that could cause a panic, namely within using `Result`.  Methods such as `unwrap()` and `expect()` can cause a panic if the `Result` is `None`, as the error is not being handled.  As a result, the program simply panics and closes to prevent any further unwanted behavior.
 
 The program should only panic if it could be in a "bad" state, where there is invalid data flowing within the program.  Ideally, errors should be recoverable if possible.  Concepts like logic flows and pattern matching help with handling different types and Errors, which will be apparent in the next section.

--- a/docs/Rust/section5/intro.md
+++ b/docs/Rust/section5/intro.md
@@ -7,7 +7,7 @@ description: An introduction to intermediate Rust, specifically how to utilize d
 
 This module will delve into some more intermediate concepts: collections and data structs.
 
+- [Vectors, Strings & Hashmaps](./collections.md)
 - [Structs](./structs.md)
 - [Defining Methods for Structs](./struct-methods.md)
-- [Vectors, Strings & Hashmaps](./collections.md)
 - [Vectors vs Strings - what’s the difference?](./vectors-vs-strings.md)

--- a/docs/Rust/section7/intro.md
+++ b/docs/Rust/section7/intro.md
@@ -7,6 +7,6 @@ description: An introduction to advanced Rust, specifically iterators and closur
 
 Delving deeper into more of the Rust Standard Library's extended functionality and more advanced concepts: iterators and closures.
 
-- [Using Closures for Ultimate Code Reuse](./closures.md)
 - [Using Iterators with Vectors](./iterators.md)
+- [Using Closures for Ultimate Code Reuse](./closures.md)
 - [Macros](./macros.md)

--- a/sidebars.js
+++ b/sidebars.js
@@ -266,8 +266,8 @@ module.exports = {
       items: [
         'Rust/section8/section-8-intro',
         'Rust/section8/defining-cargo-config',
-        'Rust/section8/defining-crate-features',
         'Rust/section8/installing-crate',
+        'Rust/section8/defining-crate-features',
         'Rust/section8/unit-tests'
 
       ],


### PR DESCRIPTION
Thanks for all the great effort put into bringing this valuable document into life.

Just noticed some minor typos.

This PR fixes those.