### PR TITLE
Add styling to links

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -279,3 +279,11 @@ a:hover.navbar__item {
   text-align: center;
   margin: 20px;
 }
+
+.markdown a {
+  color: #38aa69;
+}
+
+.markdown a:hover {
+  color: #4eeb92;
+}


### PR DESCRIPTION
Links currently are not visible (see issue #137 )

This PR adds some styling to solve this.  On hover, they are underlined and a lighter color: 

<img width="852" alt="Screenshot 2023-09-17 at 6 11 16 PM" src="https://github.com/w3f/w3f-education/assets/26698074/00a46ecf-2601-426c-a236-ac2b821d8509">

Closes #137.  Of course, the color can always be changed :) 